### PR TITLE
Change reading a file at once to use to throw exception when tellg indicates an invalid state

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,7 @@ IncludeJagatiPackage("Foundation")
 AddJagatiException("IOStream" "Base" "Base Exception for IO Streams.")
 
 AddJagatiException("StreamOverflow" "IOStream" "Something too large was jammed into or pulled out of a stream.")
+AddJagatiException("StreamReadError" "IOStream" "Failed to extract Data from a stream.")
 
 EmitExceptionSource()
 

--- a/include/TextStreamReader.h
+++ b/include/TextStreamReader.h
@@ -94,6 +94,7 @@ namespace Mezzanine
         /// @n @n
         /// This might produce a very large String. Be mindful of the Streams size when using this.
         /// @return Returns a String containing the entire contents of the Stream.
+        /// @throw If the underlying stream has issues this can throw a Mezzanine::Exception::StreamReadError .
         [[nodiscard]] String GetAsString();
         /// @brief Gets whether or not the read position has reached the end of the Stream
         /// @return Returns true if the Stream has reached EoF, false otherwise.

--- a/src/TextStreamReader.cpp
+++ b/src/TextStreamReader.cpp
@@ -102,7 +102,7 @@ namespace Mezzanine
 
         String ToReturn(ReturnSize,0);
         this->Stream->seekg(0,std::ios::beg);
-        this->Stream->read(&ToReturn[0], ReturnSizeRaw);
+        this->Stream->read(&ToReturn[0],static_cast<StreamSize>(ReturnSizeRaw));
 
         this->Stream->seekg(SavedReadPos); // Put the stream back how we found it
         return ToReturn;

--- a/test/TextStreamReaderTests.h
+++ b/test/TextStreamReaderTests.h
@@ -44,6 +44,7 @@
 /// @brief This file tests the functionality of the TextStreamReader class.
 
 #include "MezzTest.h"
+#include "MezzException.h"
 
 #include "TextStreamReader.h"
 
@@ -65,6 +66,16 @@ AUTOMATIC_TEST_GROUP(TextStreamReaderTests,TextStreamReader)
 
     TEST_EQUAL("GetAsString()",
                TestBuffer,TestReader.GetAsString())
+    TEST_THROW("GetAsString()-MissingFileStream",
+               Mezzanine::Exception::StreamReadError,
+               [](){
+                    Mezzanine::TextStreamReader Reader(
+                        std::make_shared<std::ifstream>("ZZZ_NoSuchFile.txt.bad", std::ios::in)
+                    );
+                    std::cerr << Reader.GetAsString();
+
+    })
+
 
     String FirstReadResult = TestReader.Read(14);
     TEST_EQUAL("Read(const_StreamSize)-First",


### PR DESCRIPTION
And used stream.read per microbenchmark results.